### PR TITLE
freegeoip.net is discontinued. Changed url to freegeoip.app.

### DIFF
--- a/FreeGeoIp.php
+++ b/FreeGeoIp.php
@@ -13,12 +13,12 @@
 		/**
 		* @const string API url
 		*/
-		const API_BASE_URL = 'http://freegeoip.net';
+		const API_BASE_URL = 'https://freegeoip.app';
 		
 		/**
-        * @var string responseFormat
+		* @var string responseFormat
 		* API call request format - csv, xml, json
-        */
+		*/
 		private $responseFormat;
 	
 		


### PR DESCRIPTION
Hey there! Hoping its ok if I make a small pull request for this wrapper - I found it useful for a project. 

Freegeoip.net was shutdown a year or so ago. I changed the base url to freegeoip.app, which is active and provides the same API. Also specified the URL use https - the wrapper will throw an error upon encountering a redirect.

Thanks